### PR TITLE
Time stamp for sample using ATOMIC_BLOCK

### DIFF
--- a/Debouncer/DebouncerImpl.h
+++ b/Debouncer/DebouncerImpl.h
@@ -82,9 +82,8 @@ public:
         uint32_t curr_ms = millis();
 
         // Temporarily disable interrupts to ensure an accurate time stamp for the sample.
-        ATOMIC_BLOCK( ATOMIC_RESTORESTATE )
+        ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
         {
-          noInterrupts();
           curr_state = digitalRead(pin_target);  // No interrupt will occur between here...
           curr_ms = millis();                    // ...and here, ensuring an accurate time stamp for the sample.
         }

--- a/Debouncer/DebouncerImpl.h
+++ b/Debouncer/DebouncerImpl.h
@@ -82,11 +82,15 @@ public:
         uint32_t curr_ms = 0;
 
         // Temporarily disable interrupts to ensure an accurate time stamp for the sample.
+#ifdef ATOMIC_BLOCK
         ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
         {
-          curr_state = digitalRead(pin_target);  // No interrupt will occur between here...
-          curr_ms = millis();                    // ...and here, ensuring an accurate time stamp for the sample.
+#endif
+          input_state = digitalRead(input_pin);  // No interrupts will occur between here...
+          current_ms = millis();                 // ...and here, ensuring an accurate time stamp for the sample.
+#ifdef ATOMIC_BLOCK
         }
+#endif
         is_stable_edge = false;
 
         if (curr_state != prev_state)

--- a/Debouncer/DebouncerImpl.h
+++ b/Debouncer/DebouncerImpl.h
@@ -58,7 +58,7 @@ private:
 
 public:
 
-    Debouncer(const int8_t pin, const uint16_t duration_ms, const Active active = Active::L, const DurationFrom mode = DurationFrom::STABLE)
+    Debouncer(const uint8_t pin, const uint16_t duration_ms, const Active active = Active::L, const DurationFrom mode = DurationFrom::STABLE)
     : pin_target(pin)
     , duration_ms(duration_ms)
     , unstable_change_begin_ms(0xFFFFFFFF)

--- a/Debouncer/DebouncerImpl.h
+++ b/Debouncer/DebouncerImpl.h
@@ -141,7 +141,7 @@ private:
 
     const uint8_t pin_target;
 
-    uint32_t duration_ms;
+    const uint32_t duration_ms;
     uint32_t unstable_change_begin_ms;
     uint32_t unstable_change_end_ms;
 

--- a/Debouncer/DebouncerImpl.h
+++ b/Debouncer/DebouncerImpl.h
@@ -78,8 +78,8 @@ public:
 
     void update()
     {
-        bool curr_state = digitalRead(pin_target);
-        uint32_t curr_ms = millis();
+        bool curr_state = false;
+        uint32_t curr_ms = 0;
 
         // Temporarily disable interrupts to ensure an accurate time stamp for the sample.
         ATOMIC_BLOCK(ATOMIC_RESTORESTATE)

--- a/Debouncer/DebouncerImpl.h
+++ b/Debouncer/DebouncerImpl.h
@@ -57,7 +57,7 @@ private:
 
 public:
 
-    Debouncer(uint8_t pin, uint16_t duration_ms, Active active = Active::L, DurationFrom mode = DurationFrom::STABLE)
+    Debouncer(const int8_t pin, const uint16_t duration_ms, const Active active = Active::L, const DurationFrom mode = DurationFrom::STABLE)
     : pin_target(pin)
     , duration_ms(duration_ms)
     , unstable_change_begin_ms(0xFFFFFFFF)
@@ -69,21 +69,22 @@ public:
     , mode(mode)
     {}
 
-    bool read() { return stable_state; }
+    bool read() const { return stable_state; }
 
-    bool edge() { return is_stable_edge; }
-    bool rising() { return (stable_state == HIGH) && is_stable_edge; }
-    bool falling() { return (stable_state == LOW) && is_stable_edge; }
+    bool edge() const { return is_stable_edge; }
+    bool rising() const { return (stable_state == HIGH) && is_stable_edge; }
+    bool falling() const { return (stable_state == LOW) && is_stable_edge; }
 
     void update()
     {
-        bool curr_state = digitalRead(pin_target);
+        const bool curr_state = digitalRead(pin_target);
+        const uint32_t curr_ms = millis();
         is_stable_edge = false;
 
         if (curr_state != prev_state)
         {
-            if (!is_unstable) unstable_change_begin_ms = millis();
-            unstable_change_end_ms = millis();
+            if (!is_unstable) unstable_change_begin_ms = curr_ms;
+            unstable_change_end_ms = curr_ms;
             is_unstable = true;
             prev_state = curr_state;
         }
@@ -95,7 +96,7 @@ public:
                 if (mode == DurationFrom::STABLE) prev_ms = unstable_change_end_ms;
                 else                              prev_ms = unstable_change_begin_ms;
 
-                if ((millis() - prev_ms) > duration_ms)
+                if ((curr_ms - prev_ms) > duration_ms)
                 {
                     if (is_unstable)
                     {
@@ -114,14 +115,14 @@ public:
                         // auto p = callbacks.equal_range((bool)edge);
                         // for (auto it = p.first; it != p.second; ++it) it->second();
 
-                        for (auto& c : callbacks) if (edge == c.key) c.func();
+                        for (const auto& c : callbacks) if (edge == c.key) c.func();
                     }
                 }
             }
         }
     }
 
-    void subscribe(Edge edge, CallbackType func)
+    void subscribe(const Edge edge, const CallbackType func)
     {
         // TODO: std::multimap couldn't build on teensy...
         // callbacks.emplace(std::make_pair(edge, func));

--- a/Debouncer/DebouncerImpl.h
+++ b/Debouncer/DebouncerImpl.h
@@ -3,8 +3,8 @@
 #define DEBOUNCERIMPL_H
 
 #include <Arduino.h>
-#include <util/atomic.h>
 #ifdef __AVR__
+#include <util/atomic.h>
 #include "RingBuffer.h"
 #else
 #include <functional>
@@ -81,14 +81,14 @@ public:
         bool curr_state = false;
         uint32_t curr_ms = 0;
 
-        // Temporarily disable interrupts to ensure an accurate time stamp for the sample.
-#ifdef ATOMIC_BLOCK
+        // For AVR, temporarily disable interrupts to ensure an accurate time stamp for the sample.
+#ifdef __AVR__
         ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
         {
 #endif
-          input_state = digitalRead(input_pin);  // No interrupts will occur between here...
-          current_ms = millis();                 // ...and here, ensuring an accurate time stamp for the sample.
-#ifdef ATOMIC_BLOCK
+          curr_state = digitalRead(pin_target);  // For AVR, no interrupts will occur between here...
+          curr_ms = millis();                    // ...and here, ensuring an accurate time stamp for the sample.
+#ifdef __AVR__
         }
 #endif
         is_stable_edge = false;


### PR DESCRIPTION
Placed the read of the input pin and the read of the millis timer within an ATOMIC_BLOCK to ensure an accurate time stamp for the sample. Also, only read the millis timer once per sample, and use this time stamp for subsequent time difference calculations.